### PR TITLE
added in exception to deal with not having enough bitcoins.

### DIFF
--- a/src/bitcoin.inc
+++ b/src/bitcoin.inc
@@ -700,6 +700,9 @@ class BitcoinClient extends jsonrpc_client {
       throw new BitcoinClientException("sendtoaddress requires an amount to send");
     if (!is_numeric($amount))
       throw new BitcoinClientException("sendtoaddress requires the amount sent to be a number");
+    $balance = $this->getbalance();
+    if ($amount > $balance)
+     throw new BitcoinClientException("Amount " . $amount . " is more than your current balance of: " . $balance);
     $amount = floatval($amount);
     if (!$comment && !$comment_to)
       return $this->query("sendtoaddress", $address, $amount);


### PR DESCRIPTION
Hi Mike,
  I've started using your library quite a bit, its very helpful.   I did find that you've got Ctrl-Ms (Carriage Returns) in your file at the end of every line, which I've removed. 

 I've only added three lines in the sendtoaddress() method which checks to see if the person has enough bitcoins in their wallet to actually send the amount they want to send.  However, because I removed all of these CRs, it will appear as if every line has changed.   Not sure if there is a way around this for you in the editor you use, it'd be great to have them removed and typically you can save your files without the Carriage Returns.

I'm sending this pull request more as a test of the process, I expect that the next time I send a pull request I'll have a lot more code for you to integrate.
