### PR TITLE
Check for invalid characters when base58-decoding.

### DIFF
--- a/src/bitcoin.inc
+++ b/src/bitcoin.inc
@@ -78,6 +78,11 @@ class Bitcoin {
   private function decodeBase58($base58) {
     $origbase58 = $base58;
 
+    //only valid chars allowed
+    if (preg_match('/[^1-9A-HJ-NP-Za-km-z]/', $base58)) {
+      return "";
+    }
+
     $return = "0";
     for ($i = 0; $i < strlen($base58); $i++) {
       $current = (string) strpos(Bitcoin::$base58chars, $base58[$i]);


### PR DESCRIPTION
Currently, bitcoin-php considers this address valid: 17FSKMPAyXGR7EQziCqbVfwleGumRosQoh

However, it contains a lowercase l, which is not an allowed character in base58. This patch adds an extra check to prevent this case.
